### PR TITLE
Add Draft Mode support for previewing unpublished content

### DIFF
--- a/app/api/draft/route.ts
+++ b/app/api/draft/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest } from "next/server";
+import { redirect } from "next/navigation";
+import { cookies, draftMode } from "next/headers";
+import { fetchPost } from "@/lib/fetchPost";
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const secret = searchParams.get("secret");
+  const slug = searchParams.get("slug");
+
+  // Validate secret and slug
+  if (secret !== process.env.DRAFT_MODE_SECRET || !slug) {
+    return new Response("Invalid token or slug.", { status: 401 });
+  }
+
+  // Fetch the post
+  const { post } = await fetchPost(slug);
+  if (!post?.slug) {
+    return new Response("Post does not exist.", { status: 400 });
+  }
+
+  // Enable Draft Mode
+  const draft = await draftMode();
+  draft.enable();
+
+  // Adjust Draft Mode cookie for Contentful compatibility. sameSite none, secure false
+  // https://www.contentful.com/developers/docs/tutorials/preview/live-preview/
+  const cookieStore = await cookies();
+  const draftCookie = cookieStore.get("__prerender_bypass");
+  if (draftCookie) {
+    cookieStore.set({
+      ...draftCookie,
+      httpOnly: true,
+      secure: true,
+      sameSite: "none",
+    });
+  }
+
+  // Redirect to fetched post's slug to prevent open redirect vulnerabilities
+  redirect(`/posts/${post.slug}`);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
 import Header from "@/components/header";
+import DraftIndicator from "@/components/draft-indicator";
 
 const interVariable = localFont({
   src: "../assets/fonts/InterVariable.woff2",
@@ -23,6 +24,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
     <html lang="en">
       <body className={`${interVariable.variable} antialiased`}>
         <Header />
+        <DraftIndicator />
         {children}
       </body>
     </html>

--- a/components/draft-indicator.tsx
+++ b/components/draft-indicator.tsx
@@ -1,0 +1,17 @@
+import { draftMode } from "next/headers";
+
+export default async function DraftIndicator() {
+  const { isEnabled } = await draftMode();
+  if (!isEnabled) return;
+
+  return (
+    <div className="fixed bottom-0 right-0 z-50 m-4">
+      <div className="rounded border bg-background/50 p-2 backdrop-blur">
+        <p className="flex gap-1 text-copy-tertiary">
+          <span className="text-orange-400">•</span>
+          Draft Mode Active
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/post-item.tsx
+++ b/components/post-item.tsx
@@ -1,12 +1,19 @@
 import Link from "next/link";
 import { PostFieldsFragment } from "@/lib/graphql/__generated__/sdk";
 import { formatDate } from "@/lib/utils";
+import { draftMode } from "next/headers";
 
-export default function PostItem({ post }: { post: PostFieldsFragment }) {
+export default async function PostItem({ post }: { post: PostFieldsFragment }) {
+  const { isEnabled: preview } = await draftMode();
+  const isDraft = preview && !post.sys.publishedAt;
+
   return (
     <div className="block md:flex md:items-end md:gap-2">
       <div className="decoration-transparent duration-200 md:underline md:hover:decoration-copy-primary">
-        <Link href={`/posts/${post.slug}`}>{post.title}</Link>
+        <Link href={`/posts/${post.slug}`}>
+          <span className={isDraft ? "text-orange-400" : "hidden"}>• </span>
+          {post.title}
+        </Link>
       </div>
       <div className="mb-1 hidden h-full flex-1 border-b border-copy-tertiary/10 md:block" />
       <p className="text-copy-tertiary">

--- a/lib/graphql/Post.gql
+++ b/lib/graphql/Post.gql
@@ -3,6 +3,7 @@ fragment PostFields on Post {
   __typename
   sys {
     id
+    publishedAt
   }
   title
   slug


### PR DESCRIPTION
### Summary

Draft mode allows users to temporarily bypass statically generated pages, and securely fetch unpublished content using the preview `gqlClient`. This feature is useful for previewing posts directly from the CMS before publishing.

- **Draft Mode**
  - Added `/api/draft` route to enable draft mode when a valid token is provided.
  - Added a draft mode indicator overlay to notify users when they are in draft mode.
  - Added a post draft indicator, allowing users in draft mode to easily identify unpublished posts.